### PR TITLE
support sourcemap and change model API

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,7 +28,8 @@
     "jquery-deparam": "~0.2.0",
     "jsx-requirejs-plugin": "~0.5.2",
     "FileSaver": "*",
-    "canvg-gabelerner": "*"
+    "canvg-gabelerner": "*",
+    "vlq": "~0.2.0"
   },
   "overrides": {
     "requirejs-domready": {

--- a/src/apps/chart.jade
+++ b/src/apps/chart.jade
@@ -15,7 +15,8 @@ block navleft
   ul.nav.navbar-nav
     li
       button#e2d3-rebind.btn.btn-sm.btn-default.navbar-btn(data-toggle='tooltip', data-placement='right', title='Click when you change selected area')
-        i.fa.fa-refresh
+        i.fa.fa-table
+        |  Link Data
 
 block navright
   ul.nav.navbar-nav.navbar-right

--- a/src/lib/coffee/e2d3api.coffee
+++ b/src/lib/coffee/e2d3api.coffee
@@ -44,7 +44,7 @@ define ['jquery', 'underscore', 'd3', 'queue'], ($, _, d3, queue) ->
               extmap = _.object(exts)
 
               charts.push
-                title: baseUrls[i].replace /^\/contrib/, 'e2d3'
+                title: baseUrls[i].replace /^\/contrib/, 'e2d3/e2d3-contrib'
                 baseUrl: baseUrls[i]
                 scriptType: extmap['main']
                 dataType: extmap['data']

--- a/src/lib/coffee/e2d3excel.coffee
+++ b/src/lib/coffee/e2d3excel.coffee
@@ -1,15 +1,6 @@
 define ['params!', 'd3', 'e2d3model', 'e2d3util'], (params, d3, model, util) ->
   ChartDataTable = model.ChartDataTable
 
-  REGEXP_NUMBER = /^[-+]?(\d{1,3}(,?\d{3})*(\.\d+)?|\.\d+)([eE][-+]?\d+)?$/
-
-  normalizeDataType = (rows) ->
-    for row in rows
-      for value, i in row
-        if REGEXP_NUMBER.test value
-          row[i] = +(value.replace /,/, '')
-    rows
-
   ###
   # Excel API
   ###
@@ -24,7 +15,7 @@ define ['params!', 'd3', 'e2d3model', 'e2d3util'], (params, d3, model, util) ->
       new Promise (resolve, reject) =>
         @binding.getDataAsync valueFormat: Office.ValueFormat.Formatted, (result) ->
           if result.status == Office.AsyncResultStatus.Succeeded
-            resolve new ChartDataTable normalizeDataType result.value
+            resolve new ChartDataTable result.value
           else
             resolve new ChartDataTable []
 
@@ -83,7 +74,7 @@ define ['params!', 'd3', 'e2d3model', 'e2d3util'], (params, d3, model, util) ->
   class DummyExcelAPI
     fill: (type, text, callback) ->
       new Promise (resolve, reject) ->
-        @rows = normalizeDataType d3[type].parseRows text
+        @rows = d3[type].parseRows text
         resolve()
 
     bindSelected: (callback) ->

--- a/src/lib/coffee/e2d3loader.coffee
+++ b/src/lib/coffee/e2d3loader.coffee
@@ -1,4 +1,4 @@
-define ['text', 'coffee-script'], (text, CoffeeScript) ->
+define ['text', 'coffee-script', 'vlq'], (text, CoffeeScript, vlq) ->
   'use strict';
 
   generate = (src, modules) ->
@@ -93,19 +93,44 @@ define([#{moduleNamesWithQuote}], function (#{moduleNames}) {
     load: (name, req, onLoadNative, config) ->
       req ['JSXTransformer'], (JSXTransformer) ->
         onLoad = (content) ->
-          firstLine = (content.split /\r\n|\r|\n/)[0]
+          lines = content.split /\r\n|\r|\n/
+          mappingsPrefix = ';;;;;;;;'
+
+          srcmap =
+            version: 3
+            file: 'evaluated'
+            sourceRoot: config.baseUrl
+            sources: [name]
+            sourcesContent: [content]
+            names: []
 
           try
             if /.coffee$/.test name
-              options = bare: true, header: false, inline: true
-              content = CoffeeScript.compile(content, options)
+              options =
+                bare: true
+                header: false
+                inline: true
+                sourceMap: true
+              compiled = CoffeeScript.compile(content, options)
+              content = compiled.js
+              originalSourceMap = JSON.parse(compiled.v3SourceMap)
+              srcmap.mappings = mappingsPrefix + originalSourceMap.mappings
             else if /.jsx$/.test name
-              options = {}
-              content = JSXTransformer.transform(content, options).code
+              compiled = JSXTransformer.transform content, sourceMap: true
+              content = compiled.code
+              srcmap.mappings = mappingsPrefix + compiled.sourceMap.mappings
+            else
+              vlqs = for i in [0...lines.length]
+                diff = if i == 0 then 0 else 1
+                vlq.encode [0, 0, diff, 0]
+              srcmap.mappings = mappingsPrefix + vlqs.join ';'
           catch err
-            onLoadNative.error err
+            console.error err
 
-          content = transform content, firstLine
+          content = transform content, lines[0]
+
+          sourceMapping = btoa unescape encodeURIComponent JSON.stringify srcmap
+          content += "\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,#{sourceMapping}"
 
           onLoadNative.fromText content
 

--- a/src/lib/coffee/e2d3model.coffee
+++ b/src/lib/coffee/e2d3model.coffee
@@ -5,6 +5,8 @@ define ['d3'], (d3) ->
     desc.enumerable = false
     Object.defineProperty obj, name, desc
 
+  REGEXP_NUMBER = /^[-+]?(\d{1,3}(,?\d{3})*(\.\d+)?|\.\d+)([eE][-+]?\d+)?$/
+
   isNumber = (value) ->
     typeof value == 'number'
 
@@ -20,7 +22,7 @@ define ['d3'], (d3) ->
     ###
     transpose: () ->
       cols = d3.max(@, (row) -> row.length)
-      rows = @.length
+      rows = @length
       newarray = []
       for c in [0..cols-1]
         newarray[c] = []
@@ -35,23 +37,30 @@ define ['d3'], (d3) ->
       values = []
       for row in @
         for value in row
-          values.push value if isNumber value
+          values.push value
       values
+
+    convertToNumber: () ->
+      for row in @
+        for value, i in row
+          if REGEXP_NUMBER.test value
+            row[i] = +(value.replace /,/, '')
+      @
 
     ###
     # ChartDataKeyValueListへの変換
     ###
-    toList: (header) -> new ChartDataKeyValueList @, header
+    toList: (options) -> new ChartDataKeyValueList @, options
 
     ###
     # ChartDataKeyValueMapへの変換
     ###
-    toMap: (header) -> new ChartDataKeyValueMap @, header
+    toMap: (options) -> new ChartDataKeyValueMap @, options
 
     ###
     # ChartDataKeyValueNestedへの変換
     ###
-    toNested: (name, header) -> new ChartDataKeyValueNested @, name, header
+    toNested: (options) -> new ChartDataKeyValueNested @, options
 
   ###
   # 行毎のヘッダと値のマップ
@@ -68,7 +77,9 @@ define ['d3'], (d3) ->
   # ]
   ###
   class ChartDataKeyValueList extends Array
-    constructor: (table, header) ->
+    constructor: (table, options) ->
+      header = options?.header
+
       if !header?
         header = table[0]
         table = table[1..]
@@ -80,17 +91,27 @@ define ['d3'], (d3) ->
         obj
 
       @header = header
-      @.push.apply @, data
+      @push.apply @, data
+
+      @typing() if options?.typed
 
     ###
     # 全ての値を返す
     ###
-    values: () ->
+    values: (fields...) ->
       values = []
       for row in @
-        for name, value of row
-          values.push value if isNumber value
+        for own name, value of row
+          continue if fields? && fields.indexOf(name) == -1
+          values.push value
       values
+
+    typing: () ->
+      for row in @
+        for own name, value of row
+          if REGEXP_NUMBER.test value
+            row[name] = +(value.replace /,/, '')
+      @
 
   ###
   # 行毎のヘッダと値のマップ
@@ -107,7 +128,9 @@ define ['d3'], (d3) ->
   # }
   ###
   class ChartDataKeyValueMap
-    constructor: (table, header) ->
+    constructor: (table, options) ->
+      header = options?.header
+
       if !header?
         header = table[0][1..]
         table = table[1..]
@@ -126,17 +149,28 @@ define ['d3'], (d3) ->
       unenumerable @, 'header'
       unenumerable @, 'keys'
 
+      @typing() if options?.typed
+
     ###
     # 全ての値を返す
     ###
-    values: () ->
+    values: (fields...) ->
       values = []
       for own key, row of @
         for own name, value of row
-          values.push value if isNumber(value)
+          continue if fields? && fields.indexOf(name) == -1
+          values.push value
       values
 
+    typing: () ->
+      for own key, row of @
+        for own name, value of row
+          if REGEXP_NUMBER.test value
+            row[name] = +(value.replace /,/, '')
+      @
+
   unenumerable ChartDataKeyValueMap.prototype, 'values'
+  unenumerable ChartDataKeyValueMap.prototype, 'typing'
 
   ###
   # 入れ子構造
@@ -157,17 +191,21 @@ define ['d3'], (d3) ->
   unenumerable Node.prototype, 'findOrCreateChild'
 
   class ChartDataKeyValueNested extends Node
-    constructor: (table, name='root', count=1, header) ->
+    constructor: (table, options) ->
+      name = options?.name ? 'root'
+      valueColumnCount = options?.valueColumnCount ? 1
+      header = options?.header
+
       super name
 
       if !header?
-        header = table[0][-count..]
+        header = table[0][-valueColumnCount..]
         table = table[1..]
       lastindex = table[0].length - 1
 
       for row in table
-        path = row[0...-count]
-        values = row[-count..]
+        path = row[0...-valueColumnCount]
+        values = row[-valueColumnCount..]
 
         current = @
         for name in path
@@ -179,16 +217,6 @@ define ['d3'], (d3) ->
             current[key] = values[i]
 
       @header = header
-
-    ###
-    # 全ての値を返す
-    ###
-    values: () ->
-      values = []
-      for own key, row of @
-        for own name, value of row
-          values.push value if isNumber(value)
-      values
 
   ###
   # exports


### PR DESCRIPTION
すみません。二つの変更のコミットを混ぜてしまいました。
### ソースマップに対応

ソースマップに対応しました。VM:1231とかなっていたのが、ちゃんとmain.js、main.coffee、main.jsxとして表示されます。

console.log等の出力からソースコードに飛んでも良いですし、Sourcesタブの'localhost:8000/contrib/dot-bar-chart'とかからでもソースが見えると思います。
### モデルのAPIの変更

デフォルトで、文字列から数値への変換を行わないようにしました。

数値への変換をする場合には、toMapやtoListの引数にtyped: trueを渡してください。

``` js
data.toList({typed: true});
data.toMap({typed: true});
```

これに合わせて、toListやtoMapにヘッダを外から渡すときに、第一引数に渡していたものについても変更しました。

``` js
data.toList({header: ['name', 'age']});
data.toMap({header: ['name', 'age']});
```
