### PR TITLE
Require with name

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,7 +27,8 @@
     "jquery-deparam": "~0.2.0",
     "FileSaver": "*",
     "canvg-gabelerner": "*",
-    "vlq": "~0.2.0"
+    "vlq": "~0.2.0",
+    "requirejs-plugins": "~1.0.3"
   },
   "overrides": {
     "requirejs-domready": {

--- a/src/apps/frame.jade
+++ b/src/apps/frame.jade
@@ -32,4 +32,6 @@ html
   body
     section#e2d3-chart-area
     #log.log
+    script(src='https://www.promisejs.org/polyfills/promise-6.0.1.min.js')
+    script(src='https://www.promisejs.org/polyfills/promise-done-6.0.1.min.js')
     script(src='lib/libs.js', data-main='frame.js')

--- a/src/lib/coffee/e2d3loader.coffee
+++ b/src/lib/coffee/e2d3loader.coffee
@@ -2,15 +2,26 @@ define ['text', 'coffee-script', 'vlq'], (text, CoffeeScript, vlq) ->
   'use strict';
 
   generate = (src, modules) ->
-    moduleMap = (module) ->
-      switch module
-        when 'jquery' then '$'
-        when 'lodash' then '_'
-        when 'react' then 'React'
-        else module
+    nameMap =
+      jquery: '$'
+      lodash: '_'
 
-    moduleNames = modules.map(moduleMap).join(',')
-    moduleNamesWithQuote = modules.map((module) -> "'#{module}'").join(',')
+    moduleNameMap = (module) ->
+      idx = module.indexOf('=')
+      if idx != -1
+        module[0...idx]
+      else
+        nameMap[module] ? module
+
+    moduleMap = (module) ->
+      idx = module.indexOf('=')
+      if idx != -1
+        "'#{module[(idx+1)..-1]}'"
+      else
+        "'#{module}'"
+
+    moduleNames = modules.map(moduleNameMap).join(',')
+    moduleNamesWithQuote = modules.map(moduleMap).join(',')
 
     """
 define([#{moduleNamesWithQuote}], function (#{moduleNames}) {

--- a/src/lib/coffee/e2d3loader.coffee
+++ b/src/lib/coffee/e2d3loader.coffee
@@ -5,6 +5,7 @@ define ['text', 'coffee-script', 'vlq'], (text, CoffeeScript, vlq) ->
     nameMap =
       jquery: '$'
       lodash: '_'
+      react: 'React'
 
     moduleNameMap = (module) ->
       idx = module.indexOf('=')

--- a/src/misc/libs.js
+++ b/src/misc/libs.js
@@ -1,5 +1,9 @@
 define([
   'domReady',
+  'async',
+  'font',
+  'goog',
+  'image',
   'text',
   'params',
   'bootstrap',


### PR DESCRIPTION
GoogleMap対応のためにrequireを名前付きで行えるようにしました。

`//# require=googlemaps=async!http://maps.google.com/maps/api/js?sensor=false`

よく見たらイコールが連続で出てきてきもいかも。
- requireの結果を変数に入れられるようにした
- [requirejs-plugins](https://github.com/millermedeiros/requirejs-plugins)の導入
