### PR TITLE
[WIP] Add amdify

### DIFF
--- a/src/lib/coffee/amdify.coffee
+++ b/src/lib/coffee/amdify.coffee
@@ -1,0 +1,34 @@
+define ['text', 'compiler'], (text, compiler) ->
+  'use strict';
+
+  wrap = (compiled, exports) ->
+    wrapped = """
+define([], function () {
+  #{compiled};
+  return #{exports};
+});
+"""
+    wrapped
+
+  e2d3loader =
+    version: '0.4.0'
+
+    load: (name, req, onLoadNative, config) ->
+      idx = name.indexOf(':')
+      exports = name[0...idx]
+      name = name[idx+1..-1]
+
+      onLoad = (source) ->
+        compiler.compile req, name, source, (compiled, mappings) ->
+          wrapped = wrap compiled, exports
+          wrappedMappings = ';' + mappings
+
+          transformed = compiler.mapping wrapped, name, source, wrappedMappings, config.baseUrl
+
+          onLoadNative.fromText transformed
+
+      onLoad.error = (err) -> onLoadNative.error err
+
+      text.load(name, req, onLoad, config);
+
+  e2d3loader

--- a/src/lib/coffee/compiler.coffee
+++ b/src/lib/coffee/compiler.coffee
@@ -1,0 +1,56 @@
+define [], () ->
+
+  compileJavaScript = (req, source, callback) ->
+    lines = source.split /\r\n|\r|\n/
+    vlqs = for i in [0...lines.length]
+      if i == 0 then 'AAAA' else 'AACA'
+    script = source
+    mappings = vlqs.join ';'
+    callback script, mappings
+
+  compileCoffeeScript = (req, source, callback) ->
+    req ['coffee-script'], (CoffeeScript) ->
+      options = bare: true, header: false, inline: true, sourceMap: true
+      compiled = CoffeeScript.compile(source, options)
+      script = compiled.js
+      mappings = JSON.parse(compiled.v3SourceMap).mappings
+      callback script, mappings
+
+  compileJSX = (req, source, callback) ->
+    req ['JSXTransformer'], (JSXTransformer) ->
+      compiled = JSXTransformer.transform source, sourceMap: true
+      script = compiled.code
+      mappings = compiled.sourceMap.mappings
+      callback script, mappings
+
+  ###
+  # exports
+  ###
+  compiler =
+    compile: (req, name, source, callback) ->
+      compile =
+        if /.coffee$/.test name
+          compileCoffeeScript
+        else if /.jsx$/.test name
+          compileJSX
+        else
+          compileJavaScript
+
+      compile req, source, callback
+
+    mapping: (compiled, name, source, mappings, baseUrl) ->
+      sourceMap =
+        version: 3
+        file: 'evaluated'
+        sourceRoot: baseUrl
+        sources: [name]
+        sourcesContent: [source]
+        names: []
+        mappings: mappings
+
+      encodedSourceMap = btoa unescape encodeURIComponent JSON.stringify sourceMap
+      compiled += "\n//# sourceURL=" + name
+      compiled += "\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,#{encodedSourceMap}"
+      compiled
+
+  compiler

--- a/src/lib/coffee/e2d3loader.coffee
+++ b/src/lib/coffee/e2d3loader.coffee
@@ -1,7 +1,15 @@
-define ['text'], (text) ->
+define ['text', 'compiler'], (text, compiler) ->
   'use strict';
 
-  generate = (src, modules) ->
+  wrap = (compiled, firstLine) ->
+    # extract module names
+    if matched = firstLine.match /^\/\/#\s*require\s*=\s*(.*)$/
+      modules = matched[1].split(',').map (module) -> module.trim()
+    else if matched = firstLine.match /^##\s*require\s*=\s*(.*)$/
+      modules = matched[1].split(',').map (module) -> module.trim()
+    else
+      modules = ['d3']
+
     nameMap =
       jquery: '$'
       lodash: '_'
@@ -29,15 +37,7 @@ define([#{moduleNamesWithQuote}], function (#{moduleNames}) {
 
   var _script = function (root, baseUrl, reload) {
 
-////
-//// ORIGINAL SCRIPT START
-////
-
-#{src}
-
-////
-//// ORIGINAL SCRIPT END
-////
+#{compiled}
 
     var _functions = {};
     if (typeof update !== 'undefined') _functions.update = update;
@@ -90,70 +90,18 @@ define([#{moduleNamesWithQuote}], function (#{moduleNames}) {
 """
     wrapped
 
-  transform = (content, firstLine) ->
-    # extract module names
-    if matched = firstLine.match /^\/\/#\s*require\s*=\s*(.*)$/
-      modules = matched[1].split(',').map (module) -> module.trim()
-    else if matched = firstLine.match /^##\s*require\s*=\s*(.*)$/
-      modules = matched[1].split(',').map (module) -> module.trim()
-    else
-      modules = ['d3']
-    generate content, modules
-
-  compileJavaScript = (req, content, callback) ->
-    lines = content.split /\r\n|\r|\n/
-    vlqs = for i in [0...lines.length]
-      if i == 0 then 'AAAA' else 'AACA'
-    script = content
-    mappings = vlqs.join ';'
-    callback script, mappings
-
-  compileCoffeeScript = (req, content, callback) ->
-    req ['coffee-script'], (CoffeeScript) ->
-      options = bare: true, header: false, inline: true, sourceMap: true
-      compiled = CoffeeScript.compile(content, options)
-      script = compiled.js
-      mappings = JSON.parse(compiled.v3SourceMap).mappings
-      callback script, mappings
-
-  compileJSX = (req, content, callback) ->
-    req ['JSXTransformer'], (JSXTransformer) ->
-      compiled = JSXTransformer.transform content, sourceMap: true
-      script = compiled.code
-      mappings = compiled.sourceMap.mappings
-      callback script, mappings
-
   e2d3loader =
     version: '0.4.0'
 
     load: (name, req, onLoadNative, config) ->
-      onLoad = (content) ->
-        compile =
-          if /.coffee$/.test name
-            compileCoffeeScript
-          else if /.jsx$/.test name
-            compileJSX
-          else
-            compileJavaScript
+      onLoad = (source) ->
+        compiler.compile req, name, source, (compiled, mappings) ->
+          firstLine = (/[^\r\n]+/.exec(source))?[0]
 
-        compile req, content, (compiled, mappings) ->
-          firstLine = (/[^\r\n]+/.exec(content))?[0]
+          wrapped = wrap compiled, firstLine
+          wrappedMappings = ';;;;' + mappings
 
-          transformed = transform compiled, firstLine
-          transformedMappings = ';;;;;;;;' + mappings
-
-          sourceMap =
-            version: 3
-            file: 'evaluated'
-            sourceRoot: config.baseUrl
-            sources: [name]
-            sourcesContent: [content]
-            names: []
-            mappings: transformedMappings
-
-          encodedSourceMap = btoa unescape encodeURIComponent JSON.stringify sourceMap
-          transformed += "\n//# sourceURL=" + name
-          transformed += "\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,#{encodedSourceMap}"
+          transformed = compiler.mapping wrapped, name, source, wrappedMappings, config.baseUrl
 
           onLoadNative.fromText transformed
 

--- a/src/misc/libs.js
+++ b/src/misc/libs.js
@@ -5,6 +5,7 @@ define([
   'goog',
   'image',
   'text',
+  'amdify',
   'bootstrap',
   'd3',
   'd3.promise',


### PR DESCRIPTION
AMD未対応のライブラリ(three.js等)を読み込むための RequireJS plugin を追加。

``` js
//# require=d3,THREE=amdify!THREE:three.js
```

のように、 `amdify!<export変数名>:<ソースコード名>`の形で書く。

ひとまずは、一つの変数のみ export 出来るようにしている。
また、CoffeeScriptやJSXにも対応している。
- [x] e2d3loaderからcompilerの切り出し
- [x] amdifyの作成
- [ ] 互換性チェック等
- [ ] require定義文の書き方の再考
- [ ] 複数の define を生成して複数の変数を exports 出来るようにする(?)
